### PR TITLE
Mod output directory

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,10 +23,15 @@ const checkDataTypeCompatibility = (params) => {
 }
 
 
-module.exports = function openssl(params, callback = () => undefined) {
+module.exports = function openssl(params, outdir, callback = () => undefined) {
     const stdout = [];
     const stderr = [];
-    const dir = 'openssl/';
+    let dir = 'openssl/';
+    if(typeof outdir == 'function'){
+      callback = outdir;
+    } else {
+      dir = outdir;
+    }
     let parameters = params
 
 


### PR DESCRIPTION
Allows for passing an `outdir` option to the openssl function in order to redefine where files get created.  If no output directory is defined then call gracefully falls back to `openssl/`.  Solves issue #12. 